### PR TITLE
Fixed Login/Register forms when running in iOS and UI improvements

### DIFF
--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -1,107 +1,105 @@
-import React, { useState } from 'react';
-import { Text, View } from 'react-native';
-import * as Yup from 'yup';
-import { Formik, FormikValues } from 'formik';
-import { DefaultTheme, Button } from 'react-native-paper';
+import React, { useState } from "react";
+import { Text, View } from "react-native";
+import * as Yup from "yup";
+import { Formik, FormikValues } from "formik";
+import { DefaultTheme, Button } from "react-native-paper";
 
 // Custom components
-import Checkbox from './Checkbox';
-import TextInput from './TextInput';
+import Checkbox from "./Checkbox";
+import TextInput from "./TextInput";
 
 // Hooks
-import useIsMountedRef from '../hooks/useIsMountedRef';
-import useAuth from '../hooks/useAuth';
+import useIsMountedRef from "../hooks/useIsMountedRef";
+import useAuth from "../hooks/useAuth";
 
 type InitialValues = {
-    email: string;
-    password: string;
-    afterSubmit?: string;
+  email: string;
+  password: string;
+  afterSubmit?: string;
 };
 
 const LoginForm = () => {
-    const isMountedRef = useIsMountedRef();
-    const { login } = useAuth();
+  const isMountedRef = useIsMountedRef();
+  const { login } = useAuth();
 
-    const [securePassword, setSecurePassword] = useState(true);
+  const [securePassword, setSecurePassword] = useState(true);
 
-    const LoginSchema = Yup.object().shape({
-      email: Yup
-        .string()
-        .label('email')
-        .email('Email must be a valid email address')
-        .required('Email is required'),
-      password: Yup
-        .string()
-        .label('password')
-        .required('Password is required')
-    });
+  const LoginSchema = Yup.object().shape({
+    email: Yup.string()
+      .label("email")
+      .email("Email must be a valid email address")
+      .required("Email is required"),
+    password: Yup.string().label("password").required("Password is required"),
+  });
 
-    const handleSubmit = async (values:FormikValues) => {
-      try {
-        await login(values.email, values.password);
-        if (isMountedRef.current) {
-          values.setSubmitting(false);
-        }
-      } catch (error: any) {
-        console.error(error);
-        values.resetForm();
-        if (isMountedRef.current) {
-          values.setSubmitting(false);
-          values.setErrors({ afterSubmit: error.message });
-        }
+  const handleSubmit = async (values: FormikValues) => {
+    try {
+      await login(values.email, values.password);
+      if (isMountedRef.current) {
+        values.setSubmitting(false);
+      }
+    } catch (error: any) {
+      console.error(error);
+      values.resetForm();
+      if (isMountedRef.current) {
+        values.setSubmitting(false);
+        values.setErrors({ afterSubmit: error.message });
       }
     }
+  };
 
-    return (
-      <Formik
-        initialValues={{
-          email: '',
-          password: ''
-        } as InitialValues}
-        onSubmit={handleSubmit}
-        validationSchema={LoginSchema}
-      >
-        {({ handleChange, handleSubmit, errors, touched, isSubmitting }) => (
-          <View>
-            <TextInput
-              autoCompleteType='username'
-              textContentType='username'
-              label="email"
-              error={Boolean(touched.email && errors.email)}
-              errorMsg={errors.email}
-              keyboardType='email-address'
-              onInput={handleChange('email')}
-              theme={DefaultTheme}
-            />
-            <TextInput
-              autoCompleteType="password"
-              textContentType='password'
-              label="password"
-              error={Boolean(touched.password && errors.password)}
-              errorMsg={errors.password}
-              keyboardType='default'
-              secureTextEntry={securePassword}
-              onInput={handleChange('password')}
-              theme={DefaultTheme}
-            />
-            <Checkbox 
-              checked={!securePassword}
-              onPress={() => setSecurePassword(!securePassword)}
-              text='Show password'
-            /> 
+  return (
+    <Formik
+      initialValues={
+        {
+          email: "",
+          password: "",
+        } as InitialValues
+      }
+      onSubmit={handleSubmit}
+      validationSchema={LoginSchema}
+    >
+      {({ handleChange, handleSubmit, errors, touched, isSubmitting }) => (
+        <View>
+          <TextInput
+            autoCompleteType="username"
+            textContentType="username"
+            label="email"
+            error={Boolean(touched.email && errors.email)}
+            errorMsg={errors.email}
+            keyboardType="email-address"
+            onInput={handleChange("email")}
+            theme={DefaultTheme}
+          />
+          <TextInput
+            autoCompleteType="password"
+            textContentType="password"
+            label="password"
+            error={Boolean(touched.password && errors.password)}
+            errorMsg={errors.password}
+            keyboardType="default"
+            secureTextEntry={securePassword}
+            onInput={handleChange("password")}
+            theme={DefaultTheme}
+          />
+          <Checkbox
+            checked={!securePassword}
+            onPress={() => setSecurePassword(!securePassword)}
+            text="Show password"
+          />
 
-            <Button 
-              mode='contained'
-              loading={isSubmitting}
-              onPress={handleSubmit}
-            >
-              Submit 
-            </Button>
-            {errors.afterSubmit && <Text>{errors.afterSubmit}</Text>}
-          </View>
-        )}
-      </Formik>
-    );
-}
+          <Button
+            mode="contained"
+            loading={isSubmitting}
+            onPress={handleSubmit}
+          >
+            Submit
+          </Button>
+          {errors.afterSubmit && <Text>{errors.afterSubmit}</Text>}
+        </View>
+      )}
+    </Formik>
+  );
+};
 
 export default LoginForm;

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -37,6 +37,13 @@ const LoginForm = (props: LoginFormProps): JSX.Element => {
       name={() => <AntDesign name="user" size={24} color="black" />}
     />
   );
+
+  const lockIcon = (
+    <PaperTextInput.Icon
+      name={() => <Ionicons name="lock-closed" size={24} color="black" />}
+    />
+  );
+
   const passwordIcon = (
     <PaperTextInput.Icon
       name={() => (
@@ -110,7 +117,8 @@ const LoginForm = (props: LoginFormProps): JSX.Element => {
             secureTextEntry={!showPassword}
             onInput={handleChange("password")}
             theme={DefaultTheme}
-            left={passwordIcon}
+            right={passwordIcon}
+            left = {lockIcon}
             autoCapitalize="none"
           />
 

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -1,11 +1,15 @@
 import React, { useState } from "react";
-import { Text, View } from "react-native";
+import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
 import * as Yup from "yup";
 import { Formik, FormikValues } from "formik";
-import { DefaultTheme, Button } from "react-native-paper";
+import {
+  DefaultTheme,
+  Button,
+  TextInput as PaperTextInput,
+} from "react-native-paper";
+import { AntDesign, Ionicons } from "@expo/vector-icons";
 
 // Custom components
-import Checkbox from "./Checkbox";
 import TextInput from "./TextInput";
 
 // Hooks
@@ -18,11 +22,33 @@ type InitialValues = {
   afterSubmit?: string;
 };
 
-const LoginForm = () => {
+interface LoginFormProps {
+  onSignUpPress: () => void;
+}
+
+const LoginForm = (props: LoginFormProps): JSX.Element => {
   const isMountedRef = useIsMountedRef();
   const { login } = useAuth();
 
-  const [securePassword, setSecurePassword] = useState(true);
+  const [showPassword, setShowPassword] = useState(false);
+
+  const emailIcon = (
+    <PaperTextInput.Icon
+      name={() => <AntDesign name="user" size={24} color="black" />}
+    />
+  );
+  const passwordIcon = (
+    <PaperTextInput.Icon
+      name={() => (
+        <Ionicons
+          name={showPassword ? "eye" : "eye-off"}
+          size={24}
+          color="black"
+          onPress={() => setShowPassword(!showPassword)}
+        />
+      )}
+    />
+  );
 
   const LoginSchema = Yup.object().shape({
     email: Yup.string()
@@ -33,6 +59,7 @@ const LoginForm = () => {
   });
 
   const handleSubmit = async (values: FormikValues) => {
+    setShowPassword(false);
     try {
       await login(values.email, values.password);
       if (isMountedRef.current) {
@@ -60,32 +87,31 @@ const LoginForm = () => {
       validationSchema={LoginSchema}
     >
       {({ handleChange, handleSubmit, errors, touched, isSubmitting }) => (
-        <View>
+        <View style={styles.container}>
           <TextInput
             autoCompleteType="username"
             textContentType="username"
-            label="email"
+            label="Email"
             error={Boolean(touched.email && errors.email)}
             errorMsg={errors.email}
             keyboardType="email-address"
             onInput={handleChange("email")}
             theme={DefaultTheme}
+            left={emailIcon}
+            autoCapitalize="none"
           />
           <TextInput
             autoCompleteType="password"
             textContentType="password"
-            label="password"
+            label="Password"
             error={Boolean(touched.password && errors.password)}
             errorMsg={errors.password}
             keyboardType="default"
-            secureTextEntry={securePassword}
+            secureTextEntry={!showPassword}
             onInput={handleChange("password")}
             theme={DefaultTheme}
-          />
-          <Checkbox
-            checked={!securePassword}
-            onPress={() => setSecurePassword(!securePassword)}
-            text="Show password"
+            left={passwordIcon}
+            autoCapitalize="none"
           />
 
           <Button
@@ -95,6 +121,13 @@ const LoginForm = () => {
           >
             Submit
           </Button>
+
+          <View style={styles.row}>
+            <Text> Don’t have an account? </Text>
+            <TouchableOpacity onPress={props.onSignUpPress}>
+              <Text style={styles.link}>Sign up</Text>
+            </TouchableOpacity>
+          </View>
           {errors.afterSubmit && <Text>{errors.afterSubmit}</Text>}
         </View>
       )}
@@ -103,3 +136,18 @@ const LoginForm = () => {
 };
 
 export default LoginForm;
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: "center",
+    justifyContent: "center",
+    margin: 40,
+  },
+  row: {
+    flexDirection: "row",
+    marginTop: 15,
+  },
+  link: {
+    fontWeight: "bold",
+  },
+});

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
 import { Text, View } from 'react-native';
 import * as Yup from 'yup';
-import { useFormik, Form, FormikProvider } from 'formik';
-import {DefaultTheme, Button } from 'react-native-paper';
+import { Formik, FormikValues } from 'formik';
+import { DefaultTheme, Button } from 'react-native-paper';
 
 // Custom components
 import Checkbox from './Checkbox';
@@ -25,100 +25,82 @@ const LoginForm = () => {
     const [securePassword, setSecurePassword] = useState(true);
 
     const LoginSchema = Yup.object().shape({
-        email: Yup
-            .string()
-            .label('email')
-            .email('Email must be a valid email address')
-            .required('Email is required'),
-        password: Yup
-            .string()
-            .label('password')
-            .required('Password is required')
-      });
+      email: Yup
+        .string()
+        .label('email')
+        .email('Email must be a valid email address')
+        .required('Email is required'),
+      password: Yup
+        .string()
+        .label('password')
+        .required('Password is required')
+    });
 
-      const formik = useFormik<InitialValues>({
-        initialValues: {
-          email: '',
-          password: '',
-        },
-        validationSchema: LoginSchema,
-        onSubmit: async (values, { setErrors, setSubmitting, resetForm }) => {
-          try {
-            await login(values.email, values.password);
-            // enqueueSnackbar('Login success', {
-            //   variant: 'success',
-            //   action: (key) => (
-            //     <MIconButton size="small" onClick={() => closeSnackbar(key)}>
-            //       {/* <Icon icon={closeFill} /> */}
-            //     </MIconButton>
-            //   )
-            // });
-            if (isMountedRef.current) {
-              setSubmitting(false);
-            }
-          } catch (error: any) {
-            console.error(error);
-            resetForm();
-            if (isMountedRef.current) {
-              setSubmitting(false);
-              setErrors({ afterSubmit: error.message });
-            }
-          }
+    const handleSubmit = async (values:FormikValues) => {
+      try {
+        await login(values.email, values.password);
+        if (isMountedRef.current) {
+          values.setSubmitting(false);
         }
-      });
-
-    const { errors, touched, values, isSubmitting, handleSubmit, getFieldProps, handleChange} = formik;
-
-
+      } catch (error: any) {
+        console.error(error);
+        values.resetForm();
+        if (isMountedRef.current) {
+          values.setSubmitting(false);
+          values.setErrors({ afterSubmit: error.message });
+        }
+      }
+    }
 
     return (
-        <View>
-            <FormikProvider value={formik}>
-                <Form autoComplete="off" noValidate onSubmit={handleSubmit}>
-                    <TextInput
-                        autoCompleteType='username'
-                        textContentType='username'
-                        label="email"
-                        error={Boolean(touched.email && errors.email)}
-                        errorMsg={errors.email}
-                        keyboardType='email-address'
-                        onInput={handleChange('email')}
-                        theme={DefaultTheme}
-                    />
-        
-                    <TextInput
-                        autoCompleteType="password"
-                        textContentType='password'
-                        label="password"
-                        error={Boolean(touched.password && errors.password)}
-                        errorMsg={errors.password}
-                        keyboardType='default'
-                        secureTextEntry={securePassword}
-                        onInput={handleChange('password')}
-                        theme={DefaultTheme}
-                    />
+      <Formik
+        initialValues={{
+          email: '',
+          password: ''
+        } as InitialValues}
+        onSubmit={handleSubmit}
+        validationSchema={LoginSchema}
+      >
+        {({ handleChange, handleSubmit, errors, touched, isSubmitting }) => (
+          <View>
+            <TextInput
+              autoCompleteType='username'
+              textContentType='username'
+              label="email"
+              error={Boolean(touched.email && errors.email)}
+              errorMsg={errors.email}
+              keyboardType='email-address'
+              onInput={handleChange('email')}
+              theme={DefaultTheme}
+            />
+            <TextInput
+              autoCompleteType="password"
+              textContentType='password'
+              label="password"
+              error={Boolean(touched.password && errors.password)}
+              errorMsg={errors.password}
+              keyboardType='default'
+              secureTextEntry={securePassword}
+              onInput={handleChange('password')}
+              theme={DefaultTheme}
+            />
+            <Checkbox 
+              checked={!securePassword}
+              onPress={() => setSecurePassword(!securePassword)}
+              text='Show password'
+            /> 
 
-                    {/* Show password??? */}
-                    
-                    <Checkbox 
-                        checked={!securePassword}
-                        onPress={() => setSecurePassword(!securePassword)}
-                        text='Show password'
-                    /> 
-
-                    <Button 
-                        mode='contained'
-                        loading={isSubmitting}
-                        onPress={handleSubmit}
-                    > 
-                        Submit 
-                    </Button>
-
-                    
-                </Form>
-            </FormikProvider>
+            <Button 
+              mode='contained'
+              loading={isSubmitting}
+              onPress={handleSubmit}
+            >
+              Submit 
+            </Button>
             {errors.afterSubmit && <Text>{errors.afterSubmit}</Text>}
-        </View>
+          </View>
+        )}
+      </Formik>
     );
 }
 

--- a/src/components/RegisterForm.tsx
+++ b/src/components/RegisterForm.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import * as Yup from 'yup';
 import { Text, View } from 'react-native';
-import { useFormik, Form, FormikProvider } from 'formik';
+import { useFormik, Form, FormikProvider, FormikValues, Formik } from 'formik';
 import { DefaultTheme, Button } from 'react-native-paper';
 
 // Custom components
@@ -46,38 +46,35 @@ const RegisterForm = () => {
             .min(6, "Password must be at least 6 characters long.")
     });
 
-    const formik = useFormik<InitialValues>({
-        initialValues: {
-          firstName: '',
-          lastName: '',
-          email: '',
-          password: ''
-        },
-        validationSchema: RegisterSchema,
-        onSubmit: async (values, { setErrors, setSubmitting }) => {
-          try {
+    const handleSubmit = async (values: FormikValues) => {
+        const { setErrors, setSubmitting } = values;
+        try {
             await register(values.email, values.password, values.firstName, values.lastName);
-            
             if (isMountedRef.current) {
               setSubmitting(false);
             }
-          } catch (error: any) {
+        } catch (error: any) {
             console.error(error);
             if (isMountedRef.current) {
-              setErrors({ afterSubmit: error.message });
-              setSubmitting(false);
+                setErrors({ afterSubmit: error.message });
+                setSubmitting(false);
             }
-          }
         }
-    });
+    }
 
-
-    const { errors, touched, handleSubmit, isSubmitting, getFieldProps, handleChange } = formik;
-    
     return (
-        <View>
-            <FormikProvider value={formik}>
-                <Form autoComplete="off" noValidate onSubmit={handleSubmit}>            
+        <Formik
+            initialValues={{
+                firstName: '',
+                lastName: '',
+                email: '',
+                password: ''
+            } as InitialValues}
+            onSubmit={handleSubmit}
+            validationSchema={RegisterSchema}
+        >
+            {({ handleChange, handleSubmit, errors, touched, isSubmitting }) => (
+                <View>
                     <TextInput
                         label="First name"
                         error={Boolean(touched.firstName && errors.firstName)}
@@ -93,6 +90,7 @@ const RegisterForm = () => {
                         theme={DefaultTheme}
                         onInput={handleChange('lastName')}
                     />
+
                     <TextInput
                         autoCompleteType='username'
                         textContentType='username'
@@ -103,7 +101,7 @@ const RegisterForm = () => {
                         onInput={handleChange('email')}
                         theme={DefaultTheme}
                     />
-            
+                
                     <TextInput
                         autoCompleteType="password"
                         textContentType='password'
@@ -115,6 +113,7 @@ const RegisterForm = () => {
                         onInput={handleChange('password')}
                         theme={DefaultTheme}
                     />
+
                     <Button 
                         mode='contained'
                         loading={isSubmitting}
@@ -123,9 +122,9 @@ const RegisterForm = () => {
                         Register 
                     </Button>
                     {errors.afterSubmit && <Text>{errors.afterSubmit}</Text>}
-                </Form>
-            </FormikProvider>
-        </View>
+                </View>
+            )}
+        </Formik>
     );
 }
 export default RegisterForm;

--- a/src/components/RegisterForm.tsx
+++ b/src/components/RegisterForm.tsx
@@ -39,6 +39,13 @@ const RegisterForm = (props: RegisterFormProps): JSX.Element => {
       name={() => <AntDesign name="user" size={24} color="black" />}
     />
   );
+
+  const lockIcon = (
+    <PaperTextInput.Icon
+      name={() => <Ionicons name="lock-closed" size={24} color="black" />}
+    />
+  );
+
   const passwordIcon = (
     <PaperTextInput.Icon
       name={() => (
@@ -158,7 +165,8 @@ const RegisterForm = (props: RegisterFormProps): JSX.Element => {
             secureTextEntry={!showPassword}
             onInput={handleChange("password")}
             theme={DefaultTheme}
-            left={passwordIcon}
+            right={passwordIcon}
+            left = {lockIcon}
             autoCapitalize="none"
           />
 

--- a/src/components/RegisterForm.tsx
+++ b/src/components/RegisterForm.tsx
@@ -1,130 +1,138 @@
-import React, { useState } from 'react';
-import * as Yup from 'yup';
-import { Text, View } from 'react-native';
-import { useFormik, Form, FormikProvider, FormikValues, Formik } from 'formik';
-import { DefaultTheme, Button } from 'react-native-paper';
+import React, { useState } from "react";
+import * as Yup from "yup";
+import { Text, View } from "react-native";
+import { FormikValues, Formik } from "formik";
+import { DefaultTheme, Button } from "react-native-paper";
 
 // Custom components
-import TextInput from './TextInput';
+import TextInput from "./TextInput";
 
 // Hooks
-import useAuth from '../hooks/useAuth';
-import useIsMountedRef from '../hooks/useIsMountedRef';
+import useAuth from "../hooks/useAuth";
+import useIsMountedRef from "../hooks/useIsMountedRef";
 
 type InitialValues = {
-    email: string;
-    password: string;
-    firstName: string;
-    lastName: string;
-    afterSubmit?: string;
+  email: string;
+  password: string;
+  firstName: string;
+  lastName: string;
+  afterSubmit?: string;
 };
 
 const RegisterForm = () => {
-    const isMountedRef = useIsMountedRef();
-    const { register } = useAuth();
+  const isMountedRef = useIsMountedRef();
+  const { register } = useAuth();
 
-    const [securePassword, setSecurePassword] = useState(true);
+  const [securePassword, setSecurePassword] = useState(true);
 
-    const RegisterSchema = Yup.object().shape({
-        firstName: Yup.string()
-            .label('firstName')
-          .min(2, 'Too Short!')
-          .max(50, 'Too Long!')
-          .required('First name required'),
-        lastName: Yup.string()
-            .label('lastName')
-            .min(2, 'Too Short!')
-            .max(50, 'Too Long!')
-            .required('Last name required'),
-        email: Yup.string()
-            .label('email')
-            .email('Email must be a valid email address')
-            .required('Email is required'),
-        password: Yup.string()
-            .label('password')
-            .required('Password is required')
-            .min(6, "Password must be at least 6 characters long.")
-    });
+  const RegisterSchema = Yup.object().shape({
+    firstName: Yup.string()
+      .label("firstName")
+      .min(2, "Too Short!")
+      .max(50, "Too Long!")
+      .required("First name required"),
+    lastName: Yup.string()
+      .label("lastName")
+      .min(2, "Too Short!")
+      .max(50, "Too Long!")
+      .required("Last name required"),
+    email: Yup.string()
+      .label("email")
+      .email("Email must be a valid email address")
+      .required("Email is required"),
+    password: Yup.string()
+      .label("password")
+      .required("Password is required")
+      .min(6, "Password must be at least 6 characters long."),
+  });
 
-    const handleSubmit = async (values: FormikValues) => {
-        const { setErrors, setSubmitting } = values;
-        try {
-            await register(values.email, values.password, values.firstName, values.lastName);
-            if (isMountedRef.current) {
-              setSubmitting(false);
-            }
-        } catch (error: any) {
-            console.error(error);
-            if (isMountedRef.current) {
-                setErrors({ afterSubmit: error.message });
-                setSubmitting(false);
-            }
-        }
+  const handleSubmit = async (values: FormikValues) => {
+    const { setErrors, setSubmitting } = values;
+    try {
+      await register(
+        values.email,
+        values.password,
+        values.firstName,
+        values.lastName
+      );
+      if (isMountedRef.current) {
+        setSubmitting(false);
+      }
+    } catch (error: any) {
+      console.error(error);
+      if (isMountedRef.current) {
+        setErrors({ afterSubmit: error.message });
+        setSubmitting(false);
+      }
     }
+  };
 
-    return (
-        <Formik
-            initialValues={{
-                firstName: '',
-                lastName: '',
-                email: '',
-                password: ''
-            } as InitialValues}
-            onSubmit={handleSubmit}
-            validationSchema={RegisterSchema}
-        >
-            {({ handleChange, handleSubmit, errors, touched, isSubmitting }) => (
-                <View>
-                    <TextInput
-                        label="First name"
-                        error={Boolean(touched.firstName && errors.firstName)}
-                        errorMsg={errors.firstName}
-                        theme={DefaultTheme}
-                        onInput={handleChange('firstName')}
-                    />
+  return (
+    <Formik
+      initialValues={
+        {
+          firstName: "",
+          lastName: "",
+          email: "",
+          password: "",
+        } as InitialValues
+      }
+      onSubmit={handleSubmit}
+      validationSchema={RegisterSchema}
+    >
+      {({ handleChange, handleSubmit, errors, touched, isSubmitting }) => (
+        <View>
+          <TextInput
+            label="First name"
+            error={Boolean(touched.firstName && errors.firstName)}
+            errorMsg={errors.firstName}
+            theme={DefaultTheme}
+            onInput={handleChange("firstName")}
+          />
 
-                    <TextInput
-                        label="Last name"
-                        error={Boolean(touched.lastName && errors.lastName)}
-                        errorMsg={errors.lastName}
-                        theme={DefaultTheme}
-                        onInput={handleChange('lastName')}
-                    />
+          <TextInput
+            label="Last name"
+            error={Boolean(touched.lastName && errors.lastName)}
+            errorMsg={errors.lastName}
+            theme={DefaultTheme}
+            onInput={handleChange("lastName")}
+          />
 
-                    <TextInput
-                        autoCompleteType='username'
-                        textContentType='username'
-                        label="email"
-                        error={Boolean(touched.email && errors.email)}
-                        errorMsg={errors.email}
-                        keyboardType='email-address'
-                        onInput={handleChange('email')}
-                        theme={DefaultTheme}
-                    />
-                
-                    <TextInput
-                        autoCompleteType="password"
-                        textContentType='password'
-                        label="password"
-                        error={Boolean(touched.password && errors.password)}
-                        errorMsg={errors.password}
-                        keyboardType='default'
-                        secureTextEntry={securePassword}
-                        onInput={handleChange('password')}
-                        theme={DefaultTheme}
-                    />
+          <TextInput
+            autoCompleteType="username"
+            textContentType="username"
+            label="email"
+            error={Boolean(touched.email && errors.email)}
+            errorMsg={errors.email}
+            keyboardType="email-address"
+            onInput={handleChange("email")}
+            theme={DefaultTheme}
+          />
 
-                    <Button 
-                        mode='contained'
-                        loading={isSubmitting}
-                        onPress={handleSubmit}
-                    > 
-                        Register 
-                    </Button>
-                    {errors.afterSubmit && <Text>{errors.afterSubmit}</Text>}
-                </View>
-            )}
-        </Formik>
-    );
-}
+          <TextInput
+            autoCompleteType="password"
+            textContentType="password"
+            label="password"
+            error={Boolean(touched.password && errors.password)}
+            errorMsg={errors.password}
+            keyboardType="default"
+            secureTextEntry={securePassword}
+            onInput={handleChange("password")}
+            theme={DefaultTheme}
+          />
+
+          <Button
+            mode="contained"
+            loading={isSubmitting}
+            onPress={handleSubmit}
+          >
+            Register
+          </Button>
+          {errors.afterSubmit && <Text>{errors.afterSubmit}</Text>}
+        </View>
+      )}
+    </Formik>
+  );
+};
+
 export default RegisterForm;

--- a/src/components/RegisterForm.tsx
+++ b/src/components/RegisterForm.tsx
@@ -1,8 +1,13 @@
 import React, { useState } from "react";
 import * as Yup from "yup";
-import { Text, View } from "react-native";
+import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
 import { FormikValues, Formik } from "formik";
-import { DefaultTheme, Button } from "react-native-paper";
+import {
+  DefaultTheme,
+  Button,
+  TextInput as PaperTextInput,
+} from "react-native-paper";
+import { AntDesign, Ionicons } from "@expo/vector-icons";
 
 // Custom components
 import TextInput from "./TextInput";
@@ -19,11 +24,38 @@ type InitialValues = {
   afterSubmit?: string;
 };
 
-const RegisterForm = () => {
+interface RegisterFormProps {
+  onLoginPress: () => void;
+}
+
+const RegisterForm = (props: RegisterFormProps): JSX.Element => {
   const isMountedRef = useIsMountedRef();
   const { register } = useAuth();
 
-  const [securePassword, setSecurePassword] = useState(true);
+  const [showPassword, setShowPassword] = useState(false);
+
+  const userIcon = (
+    <PaperTextInput.Icon
+      name={() => <AntDesign name="user" size={24} color="black" />}
+    />
+  );
+  const passwordIcon = (
+    <PaperTextInput.Icon
+      name={() => (
+        <Ionicons
+          name={showPassword ? "eye" : "eye-off"}
+          size={24}
+          color="black"
+          onPress={() => setShowPassword(!showPassword)}
+        />
+      )}
+    />
+  );
+  const emailIcon = (
+    <PaperTextInput.Icon
+      name={() => <Ionicons name="at" size={24} color="black" />}
+    />
+  );
 
   const RegisterSchema = Yup.object().shape({
     firstName: Yup.string()
@@ -48,6 +80,7 @@ const RegisterForm = () => {
 
   const handleSubmit = async (values: FormikValues) => {
     const { setErrors, setSubmitting } = values;
+    setShowPassword(false);
     try {
       await register(
         values.email,
@@ -81,13 +114,15 @@ const RegisterForm = () => {
       validationSchema={RegisterSchema}
     >
       {({ handleChange, handleSubmit, errors, touched, isSubmitting }) => (
-        <View>
+        <View style={styles.container}>
           <TextInput
             label="First name"
             error={Boolean(touched.firstName && errors.firstName)}
             errorMsg={errors.firstName}
             theme={DefaultTheme}
             onInput={handleChange("firstName")}
+            left={userIcon}
+            autoCapitalize="words"
           />
 
           <TextInput
@@ -96,29 +131,35 @@ const RegisterForm = () => {
             errorMsg={errors.lastName}
             theme={DefaultTheme}
             onInput={handleChange("lastName")}
+            left={userIcon}
+            autoCapitalize="words"
           />
 
           <TextInput
             autoCompleteType="username"
             textContentType="username"
-            label="email"
+            label="Email"
             error={Boolean(touched.email && errors.email)}
             errorMsg={errors.email}
             keyboardType="email-address"
             onInput={handleChange("email")}
             theme={DefaultTheme}
+            left={emailIcon}
+            autoCapitalize="none"
           />
 
           <TextInput
             autoCompleteType="password"
             textContentType="password"
-            label="password"
+            label="Password"
             error={Boolean(touched.password && errors.password)}
             errorMsg={errors.password}
             keyboardType="default"
-            secureTextEntry={securePassword}
+            secureTextEntry={!showPassword}
             onInput={handleChange("password")}
             theme={DefaultTheme}
+            left={passwordIcon}
+            autoCapitalize="none"
           />
 
           <Button
@@ -128,6 +169,14 @@ const RegisterForm = () => {
           >
             Register
           </Button>
+
+          <View style={styles.row}>
+            <Text> Have an account already? </Text>
+            <TouchableOpacity onPress={props.onLoginPress}>
+              <Text style={styles.link}>Login</Text>
+            </TouchableOpacity>
+          </View>
+
           {errors.afterSubmit && <Text>{errors.afterSubmit}</Text>}
         </View>
       )}
@@ -136,3 +185,18 @@ const RegisterForm = () => {
 };
 
 export default RegisterForm;
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: "center",
+    justifyContent: "center",
+    margin: 40,
+  },
+  row: {
+    flexDirection: "row",
+    marginTop: 15,
+  },
+  link: {
+    fontWeight: "bold",
+  },
+});

--- a/src/components/TextInput.tsx
+++ b/src/components/TextInput.tsx
@@ -28,6 +28,7 @@ const TextInput = (props: TextInputProps) => {
                 textContentType={props.textContentType}
                 autoCorrect={props.autoCorrect}
                 autoComplete={props.autoCompleteType}
+                {...props}
             />
             {/* Check if we have an error/errorMsg, if we do then display it */}
             {props.error && props.errorMsg &&

--- a/src/screens/authentication/AuthScreen.tsx
+++ b/src/screens/authentication/AuthScreen.tsx
@@ -1,27 +1,23 @@
-import React, { useState } from 'react';
-import { SafeAreaView } from 'react-native';
+import React, { useState } from "react";
+import { SafeAreaView } from "react-native";
 
-import RegisterForm from '../../components/RegisterForm';
-import LoginForm from '../../components/LoginForm';
-import { Button } from 'react-native-paper';
+import RegisterForm from "../../components/RegisterForm";
+import LoginForm from "../../components/LoginForm";
+import { Button } from "react-native-paper";
 
 const AuthScreen = () => {
-    const [isRegistering, setIsRegistering] = useState(true);
+  const [isRegistering, setIsRegistering] = useState(true);
 
-    const form = (isRegistering) ? <RegisterForm /> : <LoginForm />;
-    const buttonText = (isRegistering) ? "Login" : "Register"
+  const form = isRegistering ? <RegisterForm /> : <LoginForm />;
+  const buttonText = isRegistering ? "Login" : "Register";
 
-    return (
-        <SafeAreaView>
-            {form}
-            <Button
-                onPress={() => setIsRegistering(!isRegistering)}
-                mode='outlined'
-            > 
-                {buttonText}
-            </Button>
-        </SafeAreaView>
-    );
-
-}
+  return (
+    <SafeAreaView>
+      {form}
+      <Button onPress={() => setIsRegistering(!isRegistering)} mode="outlined">
+        {buttonText}
+      </Button>
+    </SafeAreaView>
+  );
+};
 export default AuthScreen;

--- a/src/screens/authentication/AuthScreen.tsx
+++ b/src/screens/authentication/AuthScreen.tsx
@@ -1,23 +1,21 @@
 import React, { useState } from "react";
-import { SafeAreaView } from "react-native";
+import { View } from "react-native";
 
 import RegisterForm from "../../components/RegisterForm";
 import LoginForm from "../../components/LoginForm";
-import { Button } from "react-native-paper";
 
 const AuthScreen = () => {
-  const [isRegistering, setIsRegistering] = useState(true);
-
-  const form = isRegistering ? <RegisterForm /> : <LoginForm />;
-  const buttonText = isRegistering ? "Login" : "Register";
+  const [isRegistering, setIsRegistering] = useState(false);
 
   return (
-    <SafeAreaView>
-      {form}
-      <Button onPress={() => setIsRegistering(!isRegistering)} mode="outlined">
-        {buttonText}
-      </Button>
-    </SafeAreaView>
+    <View>
+      {isRegistering && (
+        <RegisterForm onLoginPress={() => setIsRegistering(false)} />
+      )}
+      {!isRegistering && (
+        <LoginForm onSignUpPress={() => setIsRegistering(true)} />
+      )}
+    </View>
   );
 };
 export default AuthScreen;

--- a/src/screens/authentication/AuthScreen.tsx
+++ b/src/screens/authentication/AuthScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { SafeAreaView, Text, View } from 'react-native';
+import { SafeAreaView } from 'react-native';
 
 import RegisterForm from '../../components/RegisterForm';
 import LoginForm from '../../components/LoginForm';
@@ -9,7 +9,7 @@ const AuthScreen = () => {
     const [isRegistering, setIsRegistering] = useState(true);
 
     const form = (isRegistering) ? <RegisterForm /> : <LoginForm />;
-    const buttonText = (isRegistering) ? "Register" : "Login"
+    const buttonText = (isRegistering) ? "Login" : "Register"
 
     return (
         <SafeAreaView>

--- a/src/screens/authentication/AuthScreen.tsx
+++ b/src/screens/authentication/AuthScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Text, View } from 'react-native';
+import { SafeAreaView, Text, View } from 'react-native';
 
 import RegisterForm from '../../components/RegisterForm';
 import LoginForm from '../../components/LoginForm';
@@ -7,32 +7,21 @@ import { Button } from 'react-native-paper';
 
 const AuthScreen = () => {
     const [isRegistering, setIsRegistering] = useState(true);
-    if (isRegistering){
-        return (
-            <View>
-                <RegisterForm />
-                <Text>
-                    Already have an account?
-                </Text>
-                <Button onPress={()=> setIsRegistering(false) } mode = 'contained'>
-                    Log in
-                </Button>
-            </View>
-        );
-    } else {
-        return (
-            <View>
-                <LoginForm />
-                <Text>
-                    Don't have an account?
-                </Text>
-                <Button onPress={()=> setIsRegistering(true)} mode = 'contained'>
 
-                    Sign up
-                </Button>
-            </View>
-        );
-    }
+    const form = (isRegistering) ? <RegisterForm /> : <LoginForm />;
+    const buttonText = (isRegistering) ? "Register" : "Login"
+
+    return (
+        <SafeAreaView>
+            {form}
+            <Button
+                onPress={() => setIsRegistering(!isRegistering)}
+                mode='outlined'
+            > 
+                {buttonText}
+            </Button>
+        </SafeAreaView>
+    );
 
 }
 export default AuthScreen;


### PR DESCRIPTION
# Overview
We were having issues when running the application on a smartphone (iOS) , due to the use of Formik's `Form` component ([documentation](https://formik.org/docs/api/form)). This `Form` component utilizes HTML elements in the back which led to breaking the application when trying to build the application for mobile.
# Fixes
- The solution for the `Form` issue was to refactor our code to follow the [example](https://formik.org/docs/guides/react-native) from Formik for react native.
    - The change doesn't hurt in performance, but made the code a little uglyish
    - In the future formik might make the `Form` component to work for react native, which we can then refactor back to make the code easier to read
# Improvements
- Added a little of styling for the `RegisterForm` and the `LoginForm`
- Cleaned up the code for the `TextInput` component to pass down additional props value to the react-native-paper's _TextInput_
- Cleaned the code inside the `AuthScreen` to pass down the Register/Login toggle down to the `LoginScreen` and `RegisterScreen`
# Results
## Login Screen
![IMG_DB6799C9C80F-1](https://user-images.githubusercontent.com/24768393/149741484-0a9714de-4a9a-4574-bda4-aba42b27f673.jpeg)
## Register Screen
![IMG_DB6799C9C80F-2](https://user-images.githubusercontent.com/24768393/149741558-e07410f1-b6fe-4a0d-b8f6-6d5496d4580d.jpeg)

