### PR TITLE
Updating to create builds in Expo

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,5 +1,6 @@
 {
   "expo": {
+    "owner": "cgalo",
     "name": "diabetes-management-app",
     "slug": "diabetes-management-app",
     "version": "1.0.0",
@@ -17,7 +18,8 @@
       "**/*"
     ],
     "ios": {
-      "supportsTablet": true
+      "supportsTablet": true,
+      "bundleIdentifier": "com.cgalo.diabetes-management-app"
     },
     "android": {
       "adaptiveIcon": {

--- a/eas.json
+++ b/eas.json
@@ -1,0 +1,18 @@
+{
+  "cli": {
+    "version": ">= 0.46.0"
+  },
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal"
+    },
+    "preview": {
+      "distribution": "internal"
+    },
+    "production": {}
+  },
+  "submit": {
+    "production": {}
+  }
+}


### PR DESCRIPTION
Updating to follow steps regarding [creating builds in Expo](https://docs.expo.dev/build/setup/).
Later on we will have to utilize these builds to deploy our application in the [Apple App Store](https://docs.expo.dev/submit/ios/) and the [Google Play Store](https://docs.expo.dev/submit/android/).