### PR TITLE
UI Improvement for TextInput components

### DIFF
--- a/src/components/TextInput.tsx
+++ b/src/components/TextInput.tsx
@@ -37,12 +37,7 @@ const styles = StyleSheet.create({
     container: {
       width: '100%',
       marginVertical: 12,
-    },
-    error: {
-      fontSize: 14,
-      paddingHorizontal: 4,
-      paddingTop: 4,
-    },
+    }
 });
 
 export default memo(TextInput);

--- a/src/components/TextInput.tsx
+++ b/src/components/TextInput.tsx
@@ -21,15 +21,13 @@ const TextInput = (props: TextInputProps):JSX.Element => {
                 autoComplete={props.autoCompleteType}
                 {...props}
             />
-            {props.errorMsg && 
-                <HelperText
-                    type='error'
-                    onPressIn={() => {}}
-                    onPressOut={() => {}}
-                >
-                    {props.errorMsg}
-                </HelperText>
-            }
+            <HelperText
+                type='error'
+                onPressIn={() => {}}
+                onPressOut={() => {}}
+            >
+                {props.errorMsg}
+            </HelperText>
         </View>
     )
 }

--- a/src/components/TextInput.tsx
+++ b/src/components/TextInput.tsx
@@ -1,6 +1,6 @@
 import React, { memo } from 'react';
 import { StyleSheet, View } from 'react-native';
-import { DefaultTheme, HelperText, TextInput as Input} from 'react-native-paper';
+import { HelperText, TextInput as Input} from 'react-native-paper';
 import { TextInputProps as InputProps } from 'react-native-paper/lib/typescript/components/TextInput/TextInput';
 
 interface TextInputProps extends InputProps {

--- a/src/components/TextInput.tsx
+++ b/src/components/TextInput.tsx
@@ -1,6 +1,6 @@
 import React, { memo } from 'react';
-import { Text, StyleSheet, View } from 'react-native';
-import { DefaultTheme, TextInput as Input} from 'react-native-paper';
+import { StyleSheet, View } from 'react-native';
+import { DefaultTheme, HelperText, TextInput as Input} from 'react-native-paper';
 import { TextInputProps as InputProps } from 'react-native-paper/lib/typescript/components/TextInput/TextInput';
 
 interface TextInputProps extends InputProps {
@@ -8,7 +8,7 @@ interface TextInputProps extends InputProps {
     errorMsg?: string | undefined;
 }
 
-const TextInput = (props: TextInputProps) => {
+const TextInput = (props: TextInputProps):JSX.Element => {
 
     const onChange = (newText: string) => {
         props.onInput(newText);
@@ -17,24 +17,19 @@ const TextInput = (props: TextInputProps) => {
     return (
         <View style={styles.container}>
             <Input 
-                label={props.label}
-                value={props.value}
-                placeholder={props.placeholder}
                 onChangeText={text => onChange(text)}
-                error={props.error}
-                mode={props.mode}
-                secureTextEntry={props.secureTextEntry}
-                keyboardType={props.keyboardType}
-                textContentType={props.textContentType}
-                autoCorrect={props.autoCorrect}
                 autoComplete={props.autoCompleteType}
                 {...props}
             />
-            {/* Check if we have an error/errorMsg, if we do then display it */}
-            {props.error && props.errorMsg &&
-                <Text>
+            {props.errorMsg && 
+                <HelperText
+                    type='error'
+                    onPressIn={() => {}}
+                    onPressOut={() => {}}
+                >
                     {props.errorMsg}
-                </Text>}
+                </HelperText>
+            }
         </View>
     )
 }


### PR DESCRIPTION
## Overview
Objective is to improve how we display errors in the `TextInput` component. Currently we manually displayed some text at the bottom of the `TextInput` component, now we'll utilize the [react-native-paper HelperText component instead](https://callstack.github.io/react-native-paper/helper-text.html) to handle this instead. 

**Note:** Originally we didn't utilize the `HelperText` component because we didn't know of the existence of it!

## Screenshots
### Before (with our own made error text)
![Old version - Simulator Screen Shot - iPhone 8 - 2022-01-31 at 21 41 59](https://user-images.githubusercontent.com/24768393/151906055-4e8335d9-7c31-4efd-ae0c-499e2b8358ed.png)

### After (with `HelperText` component from react native paper)
![New version - Simulator Screen Shot - iPhone 8 - 2022-01-31 at 21 32 36](https://user-images.githubusercontent.com/24768393/151906082-e1323f05-9cf5-4010-ada0-717c860d77d0.png)

