### PR TITLE
Defined interface for an insulin dose

### DIFF
--- a/src/@types/insulin.ts
+++ b/src/@types/insulin.ts
@@ -1,0 +1,23 @@
+import type { Timestamp } from "../@types/commons";
+
+/**
+ * Insulin dose interface
+ * Note: People with `HIGH` dose level might take an insulin dose even if they don't
+ * have had anything to eat. Therefore, we made `totalCarbs` optional.
+ * 
+ * @param totalInsulinUnits   Total units the user has to intake
+ * @param bloodGlucose        Blood Glucose measurement in milligrams per decilitre (mg/dL)
+ * @param doseLevel           Dose level of the user at the time
+ * @param createdAt           Date/Time this insulin calculation was created
+ * @param totalCarbs          Optional carbs intake used to calculate the `totalInsulinUnits`
+ * @param mealId              Optional meal related to this insuling dose
+ * 
+ */
+export interface InsulinDose {
+   totalInsulinUnits: number;
+   bloodGlucose: number;
+   doseLevel: "LOW" | "MEDIUM" | "HIGH";
+   createdAt?: Timestamp;
+   totalCarbs?: number;
+   mealId?: string;
+}


### PR DESCRIPTION
## Overview
PR covers adding the interface of a `InsulinDose`, inside `@types/insulin.ts`, and the data required for us to continue development

## References
- Resolves #32 